### PR TITLE
PGM-112: Add Docker CI/CD workflow with SBoM and attestation

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,223 @@
+name: Docker Build, Push & SBoM
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+  attestations: write
+  actions: read
+
+jobs:
+  build:
+    runs-on: self-hosted
+    timeout-minutes: 30
+    outputs:
+      image-tag: ${{ steps.tag.outputs.tag }}
+      image-digest: ${{ steps.push.outputs.digest }}
+      full-image-ref: ${{ steps.tag.outputs.full-ref }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute image tag
+        id: tag
+        env:
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          if [ "${REF_TYPE}" = "tag" ]; then
+            VERSION="${REF_NAME#v}"
+          elif [ "${EVENT_NAME}" = "pull_request" ]; then
+            VERSION="pr-${PR_NUMBER}-${SHORT_SHA}"
+          else
+            VERSION="${SHORT_SHA}"
+          fi
+          echo "tag=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "full-ref=macro.int.pgmac.net:5000/metasearch:${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Build Docker image
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          docker build --network=host \
+            -t "macro.int.pgmac.net:5000/metasearch:${TAG}" \
+            .
+
+      - name: Tag as latest
+        if: github.event_name == 'push'
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          docker tag \
+            "macro.int.pgmac.net:5000/metasearch:${TAG}" \
+            "macro.int.pgmac.net:5000/metasearch:latest"
+
+      - name: Push Docker image
+        id: push
+        if: github.event_name == 'push'
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          docker push "macro.int.pgmac.net:5000/metasearch:${TAG}"
+          docker push "macro.int.pgmac.net:5000/metasearch:latest"
+          DIGEST=$(docker inspect \
+            --format='{{index .RepoDigests 0}}' \
+            "macro.int.pgmac.net:5000/metasearch:${TAG}" \
+            | grep -oP 'sha256:[a-f0-9]+')
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
+      - name: Attest Docker image
+        id: attest-image
+        if: github.event_name == 'push'
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: macro.int.pgmac.net:5000/metasearch
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: false
+
+      - name: Upload image attestation bundle
+        if: github.event_name == 'push'
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-attestation.json
+          path: ${{ steps.attest-image.outputs.bundle-path }}
+
+      - name: Write workflow summary
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          DIGEST: ${{ steps.push.outputs.digest }}
+          EVENT_NAME: ${{ github.event_name }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          {
+            echo "## Docker Build Summary"
+            echo ""
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Image | \`macro.int.pgmac.net:5000/metasearch:${TAG}\` |"
+            if [ "${EVENT_NAME}" = "push" ]; then
+              echo "| Digest | \`${DIGEST}\` |"
+              echo "| Pushed | Yes |"
+            else
+              echo "| Pushed | No (PR build only) |"
+            fi
+            echo "| Build status | Success |"
+            echo "| Commit | \`${COMMIT_SHA}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Post or update PR comment
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          SHORT_SHA=$(git rev-parse --short HEAD)
+
+          {
+            echo "<!-- docker-build-summary -->"
+            echo "## Docker Build"
+            echo ""
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Status | Built (not pushed -- PR build only) |"
+            echo "| Tag | \`${TAG}\` |"
+            echo "| Commit | \`${SHORT_SHA}\` |"
+            echo ""
+            echo "> Image will be pushed to \`macro.int.pgmac.net:5000\` on merge to master."
+            echo "> This comment is updated on each commit."
+          } > /tmp/pr-comment.md
+
+          COMMENT_ID=$(gh pr view "${PR_NUMBER}" \
+            --json comments \
+            --jq '.comments[] | select(.body | contains("docker-build-summary")) | .databaseId' \
+            2>/dev/null | head -1 || true)
+
+          if [ -n "${COMMENT_ID}" ]; then
+            BODY=$(cat /tmp/pr-comment.md)
+            gh api "repos/${REPOSITORY}/issues/comments/${COMMENT_ID}" \
+              -X PATCH -f body="${BODY}"
+          else
+            gh pr comment "${PR_NUMBER}" --body-file /tmp/pr-comment.md
+          fi
+
+  sbom:
+    runs-on: self-hosted
+    needs: [build]
+    if: github.event_name == 'push'
+    timeout-minutes: 15
+    permissions:
+      id-token: write
+      attestations: write
+      actions: read
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate CycloneDX SBoM from Docker image
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ needs.build.outputs.full-image-ref }}
+          format: cyclonedx-json
+          output-file: docker-sbom.json
+          artifact-name: docker-sbom.json
+          upload-artifact: true
+
+      - name: Compute SHA256 digest of SBoM
+        id: sha256
+        run: |
+          echo "digest=sha256:$(sha256sum docker-sbom.json | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Attest SBoM
+        id: attest-sbom
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: docker-sbom.json
+          subject-digest: ${{ steps.sha256.outputs.digest }}
+          push-to-registry: false
+
+      - name: Upload SBoM attestation bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-sbom-attestation.json
+          path: ${{ steps.attest-sbom.outputs.bundle-path }}
+
+      - name: Upload SBoM to Dependency Track
+        uses: DependencyTrack/gh-upload-sbom@v3
+        with:
+          serverhostname: dtrack.int.pgmac.net
+          apikey: ${{ secrets.DT_APIKEY }}
+          projectname: ${{ github.repository }}
+          projectversion: ${{ needs.build.outputs.image-tag }}
+          projecttags: ${{ github.repository }}, docker, ${{ github.ref }}
+          bomfilename: docker-sbom.json
+          autocreate: true
+
+      - name: Append SBoM summary to workflow summary
+        env:
+          FULL_IMAGE_REF: ${{ needs.build.outputs.full-image-ref }}
+        run: |
+          COMPONENT_COUNT=$(jq '.components | length' docker-sbom.json 2>/dev/null || echo "unknown")
+          {
+            echo ""
+            echo "## SBoM Summary"
+            echo ""
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Format | CycloneDX JSON |"
+            echo "| Components | \`${COMPONENT_COUNT}\` |"
+            echo "| Image | \`${FULL_IMAGE_REF}\` |"
+            echo "| Dependency Track | https://dtrack.int.pgmac.net |"
+            echo "| Attestation | Attested |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -142,15 +142,10 @@ jobs:
             -H "Authorization: Bearer ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
-            | python3 -c "
-import sys, json
-for c in json.load(sys.stdin):
-    if 'docker-build-summary' in c.get('body', ''):
-        print(c['id'])
-        break
-" 2>/dev/null || true)
+            | python3 -c 'import sys,json; cs=[str(c["id"]) for c in json.load(sys.stdin) if "docker-build-summary" in c.get("body","")]; print(cs[0] if cs else "")' \
+            2>/dev/null || true)
 
-          BODY=$(python3 -c "import sys,json; print(json.dumps(sys.stdin.read()))" < /tmp/pr-comment.md)
+          BODY=$(python3 -c 'import sys,json; print(json.dumps(sys.stdin.read()))' < /tmp/pr-comment.md)
 
           if [ -n "${COMMENT_ID}" ]; then
             curl -s -X PATCH \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -138,17 +138,34 @@ jobs:
             echo "> This comment is updated on each commit."
           } > /tmp/pr-comment.md
 
-          COMMENT_ID=$(gh pr view "${PR_NUMBER}" \
-            --json comments \
-            --jq '.comments[] | select(.body | contains("docker-build-summary")) | .databaseId' \
-            2>/dev/null | head -1 || true)
+          COMMENT_ID=$(curl -s \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            | python3 -c "
+import sys, json
+for c in json.load(sys.stdin):
+    if 'docker-build-summary' in c.get('body', ''):
+        print(c['id'])
+        break
+" 2>/dev/null || true)
+
+          BODY=$(python3 -c "import sys,json; print(json.dumps(sys.stdin.read()))" < /tmp/pr-comment.md)
 
           if [ -n "${COMMENT_ID}" ]; then
-            BODY=$(cat /tmp/pr-comment.md)
-            gh api "repos/${REPOSITORY}/issues/comments/${COMMENT_ID}" \
-              -X PATCH -f body="${BODY}"
+            curl -s -X PATCH \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              -H "Content-Type: application/json" \
+              "https://api.github.com/repos/${REPOSITORY}/issues/comments/${COMMENT_ID}" \
+              -d "{\"body\": ${BODY}}"
           else
-            gh pr comment "${PR_NUMBER}" --body-file /tmp/pr-comment.md
+            curl -s -X POST \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              -H "Content-Type: application/json" \
+              "https://api.github.com/repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              -d "{\"body\": ${BODY}}"
           fi
 
   sbom:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,6 @@ COPY . .
 
 RUN make build
 
-ENV NODE_ENV production
+ENV NODE_ENV=production
 
 ENTRYPOINT ["node", "src/index.js"]

--- a/src/engines/github-users.ts
+++ b/src/engines/github-users.ts
@@ -213,7 +213,7 @@ const engine: Engine = {
             ...data.items.map((item) => ({
               modified: getUnixTime(item.updated_at),
               snippet: item.body
-                ? `<blockquote>${marked(item.body)}</blockquote>`
+                ? `<blockquote>${marked.parse(item.body)}</blockquote>`
                 : undefined,
               title: `${item.pull_request ? "PR" : "Issue"} in ${
                 item.html_url.match(/github\.com\/([^\/]+\/[^\/]+)/)?.[1]


### PR DESCRIPTION
## Summary

- Add `.github/workflows/docker.yml` — GitHub Actions workflow for Docker build, push, SBoM generation, and attestation
- Fix `marked` API: `marked()` → `marked.parse()` for compatibility with marked v5+
- Fix `Dockerfile` ENV syntax to preferred `KEY=VALUE` form

## Workflow behaviour

| Trigger | Action |
|---|---|
| PR targeting `master` | Build image, post PR comment with build result |
| Merge to `master` | Build + push to `macro.int.pgmac.net:5000`, attest image, generate Docker image SBoM, attest SBoM, upload to Dependency Track |

## Artifacts produced

| Artifact | Description |
|---|---|
| `docker-sbom.json` | CycloneDX SBoM of the Docker image |
| `docker-attestation.json` | Provenance attestation for the Docker image |
| `docker-sbom-attestation.json` | Provenance attestation for the SBoM |

## Test plan

- [ ] Open a PR targeting master — `build` job runs, PR comment appears
- [ ] Merge to master — `build` and `sbom` jobs both run, image pushed to registry, SBoM visible in Dependency Track at `dtrack.int.pgmac.net`
- [ ] Workflow summary tab shows Docker Build and SBoM tables
- [ ] Artifacts visible on the completed workflow run

## Linear

https://linear.app/pgmac-net-au/issue/PGM-112/add-github-actions-workflow-for-docker-build-push-sbom-and-attestation

🤖 Generated with [Claude Code](https://claude.com/claude-code)