### PR TITLE
feat: add Linear search engine

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -149,6 +149,11 @@ engines:
     # Jenkins user who owns the API token (optional, requires token)
     user: username
 
+  # Linear issues and tickets
+  linear:
+    # Linear personal API key (Settings > API > Personal API keys)
+    token: Ex4mp1eEx4mp1eEx4mp1eEx4mp1eEx4mp1eEx4mp1e
+
   # Jira issue titles and descriptions
   jira:
     # Jira server URL origin

--- a/src/engines/index.ts
+++ b/src/engines/index.ts
@@ -12,6 +12,7 @@ import guru from "./guru";
 import hound from "./hound";
 import jenkins from "./jenkins";
 import jira from "./jira";
+import linear from "./linear";
 import lingo from "./lingo";
 import mattermost from "./mattermost";
 import notion from "./notion";
@@ -41,6 +42,7 @@ const engines: Engine[] = [
   hound,
   jenkins,
   jira,
+  linear,
   lingo,
   mattermost,
   notion,

--- a/src/engines/linear.ts
+++ b/src/engines/linear.ts
@@ -1,0 +1,68 @@
+import axios, { AxiosInstance } from "axios";
+
+import { getUnixTime } from "../util";
+
+interface Issue {
+  identifier: string;
+  title: string;
+  description: string | null;
+  url: string;
+  updatedAt: string;
+  state: { name: string } | null;
+  team: { name: string } | null;
+}
+
+let client: AxiosInstance | undefined;
+
+const engine: Engine = {
+  id: "linear",
+  init: ({ token }: { token: string }) => {
+    client = axios.create({
+      baseURL: "https://api.linear.app",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+    });
+  },
+  isSnippetLarge: false,
+  name: "Linear",
+  search: async q => {
+    if (!client) {
+      throw Error("Engine not initialized");
+    }
+
+    try {
+      const response = await client.post("/graphql", {
+        query: `query Search($term: String!) {
+          issueSearch(term: $term, first: 50) {
+            nodes {
+              identifier
+              title
+              description
+              url
+              updatedAt
+              state { name }
+              team { name }
+            }
+          }
+        }`,
+        variables: { term: q },
+      });
+
+      const nodes: Issue[] = response.data?.data?.issueSearch?.nodes ?? [];
+
+      return nodes.map(issue => ({
+        modified: getUnixTime(issue.updatedAt),
+        snippet: issue.description ?? undefined,
+        title: `[${issue.team?.name ?? "Linear"}] ${issue.identifier}: ${issue.title}`,
+        url: issue.url,
+      }));
+    } catch (ex) {
+      console.error(`Linear search error: ${ex}`);
+      return [];
+    }
+  },
+};
+
+export default engine;


### PR DESCRIPTION
Adds a new engine that queries the Linear GraphQL API (issueSearch) to return matching issues with team, identifier, title, snippet, and modified timestamp. Registers the engine and adds example config.

<!-- Please include at least one screenshot of your change. Thanks! -->
