### PR TITLE
feat(ui): responsive layout for mobile, tablet, and desktop

### DIFF
--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Metasearch</title>
     <% if (metasearch.TRACKING_ID) { %>
     <script

--- a/src/ui/styles.scss
+++ b/src/ui/styles.scss
@@ -15,7 +15,7 @@
   --secondary-text-color: #888;
   --sidebar-hover-color: var(--bluish-white);
 
-  // @media-dependent variables
+  // @media-dependent variables — desktop defaults
   --padding-standard: 30px;
   --logo-font-size: 35px;
   --logo-margin: -1px;
@@ -27,20 +27,56 @@
   --engine-padding-left: 12px;
   --toggler-display: initial;
   --footer-display: initial;
+  --hamburger-display: none;
+  --mobile-settings-display: none;
+  --sidebar-position: relative;
+  --sidebar-transform: none;
+  --sidebar-z-index: auto;
+  --sidebar-height: auto;
+  --backdrop-display: none;
 }
 
-@media (max-height: 700px), (max-width: 700px) {
+// Tablet (640px–1023px)
+@media (max-width: 1023px) {
+  :root {
+    --sidebar-width: 200px;
+    --padding-standard: 20px;
+    --search-box-height: 46px;
+  }
+}
+
+// Short screens (e.g. landscape mobile)
+@media (max-height: 500px) {
   :root {
     --padding-standard: 5px;
-    --logo-font-size: 31px;
-    --logo-margin: -2px;
-    --search-box-height: 40px;
-    --search-box-padding-left: 15px;
-    --placeholder-opacity: 0;
+    --search-box-height: 36px;
+    --search-box-padding-left: 10px;
     --sorter-display: none;
-    --sidebar-width: 180px;
     --toggler-display: none;
     --footer-display: none;
+  }
+}
+
+// Mobile (<640px)
+@media (max-width: 639px) {
+  :root {
+    --padding-standard: 10px;
+    --logo-font-size: 28px;
+    --logo-margin: -2px;
+    --search-box-height: 42px;
+    --search-box-padding-left: 12px;
+    --placeholder-opacity: 0;
+    --sorter-display: none;
+    --sidebar-width: 240px;
+    --toggler-display: none;
+    --footer-display: none;
+    --hamburger-display: flex;
+    --mobile-settings-display: flex;
+    --sidebar-position: fixed;
+    --sidebar-transform: translateX(-100%);
+    --sidebar-z-index: 200;
+    --sidebar-height: 100dvh;
+    --backdrop-display: none; // shown via .sidebar-open
   }
 }
 
@@ -123,6 +159,20 @@ mark {
   grid-template-columns: var(--sidebar-width) 1fr auto;
   grid-template-rows: auto 1fr auto;
   height: 100vh;
+  overflow: hidden;
+
+  @media (max-width: 639px) {
+    grid-template-columns: 1fr auto;
+    grid-template-rows: auto auto 1fr auto;
+  }
+
+  &.sidebar-open .sidebar {
+    transform: translateX(0);
+  }
+
+  &.sidebar-open .sidebar-backdrop {
+    display: block;
+  }
 }
 
 .logo {
@@ -134,6 +184,26 @@ mark {
     calc(var(--padding-standard) / 2) calc(var(--padding-standard) + 9px);
   text-transform: lowercase;
   user-select: none;
+
+  @media (max-width: 639px) {
+    display: none;
+  }
+}
+
+.hamburger {
+  align-items: center;
+  background: none;
+  border: none;
+  color: var(--primary-text-color);
+  cursor: pointer;
+  display: var(--hamburger-display);
+  font-size: 1.4rem;
+  grid-area: 1 / 1 / 2 / 2;
+  justify-content: center;
+  padding: var(--padding-standard);
+  transition: color 0.4s;
+  user-select: none;
+  width: 52px;
 }
 
 .header {
@@ -141,6 +211,25 @@ mark {
   padding: var(--padding-standard) var(--padding-standard)
     calc(var(--padding-standard) / 2) 0;
   white-space: nowrap;
+
+  @media (max-width: 639px) {
+    grid-area: 1 / 2 / 2 / 3;
+    padding-left: 0;
+  }
+}
+
+.mobile-settings {
+  align-items: center;
+  display: var(--mobile-settings-display);
+  gap: 12px;
+  grid-area: 2 / 1 / 3 / 3;
+  padding: 0 var(--padding-standard) var(--padding-standard);
+
+  a {
+    color: var(--secondary-text-color);
+    font-size: 0.85rem;
+    white-space: nowrap;
+  }
 }
 
 .search-box {
@@ -195,11 +284,54 @@ mark {
   }
 }
 
+.sidebar-backdrop {
+  background: rgba(0, 0, 0, 0.4);
+  display: var(--backdrop-display);
+  inset: 0;
+  position: fixed;
+  z-index: 199;
+}
+
 .sidebar {
-  grid-area: 2 / 1 / 3 / 2;
+  background: var(--bg-color);
+  grid-area: 2 / 1 / 4 / 2;
+  height: var(--sidebar-height);
+  left: 0;
   overflow-y: auto;
   padding: 0 var(--padding-standard);
+  position: var(--sidebar-position);
+  top: 0;
+  transform: var(--sidebar-transform);
+  transition:
+    background-color 0.4s,
+    color 0.4s,
+    transform 0.25s ease;
   user-select: none;
+  z-index: var(--sidebar-z-index);
+
+  @media (max-width: 639px) {
+    grid-area: unset;
+    padding-top: var(--padding-standard);
+    width: var(--sidebar-width);
+  }
+
+  .sidebar-close {
+    background: none;
+    border: none;
+    color: var(--secondary-text-color);
+    cursor: pointer;
+    display: none;
+    font-size: 1.2rem;
+    margin-bottom: 8px;
+    padding: 4px 0;
+    transition: color 0.4s;
+    width: 100%;
+    text-align: right;
+
+    @media (max-width: 639px) {
+      display: block;
+    }
+  }
 
   ul {
     display: flex;
@@ -256,6 +388,11 @@ mark {
   padding: 0 calc(2 * var(--padding-standard)) 0 var(--padding-standard);
   position: relative; // Simplifies programmatic adjustment of scroll position
   scrollbar-color: var(--border-color) transparent;
+
+  @media (max-width: 639px) {
+    grid-area: 3 / 1 / 4 / 3;
+    padding: 0 var(--padding-standard);
+  }
 }
 
 .result-group {
@@ -340,4 +477,8 @@ h2 {
   grid-area: 3 / 1 / 4 / 2;
   padding: var(--padding-standard)
     calc(var(--padding-standard) + var(--engine-padding-left));
+
+  @media (max-width: 639px) {
+    display: none;
+  }
 }

--- a/src/ui/ui.tsx
+++ b/src/ui/ui.tsx
@@ -20,33 +20,44 @@ const querify = (params: Record<string, string> = {}) =>
 
 const Header = ({
   onChange,
+  onOpenSidebar,
   onSearch,
   q,
 }: {
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onOpenSidebar: () => void;
   onSearch: (q: string) => any;
   q: string;
 }) => (
-  <div className="header">
-    <form
-      onSubmit={e => {
-        onSearch(q);
-        e.preventDefault();
-      }}
+  <>
+    <button
+      aria-label="Open engine list"
+      className="hamburger"
+      onClick={onOpenSidebar}
     >
-      <input
-        autoFocus
-        className="search-box"
-        // For Firefox's "Add a Keyword for this Search..." feature
-        name="q"
-        onChange={onChange}
-        placeholder={"Search for anything!"}
-        type="text"
-        value={q}
-      />
-      <input className="submit" title="Search" type="submit" value="" />
-    </form>
-  </div>
+      ☰
+    </button>
+    <div className="header">
+      <form
+        onSubmit={e => {
+          onSearch(q);
+          e.preventDefault();
+        }}
+      >
+        <input
+          autoFocus
+          className="search-box"
+          // For Firefox's "Add a Keyword for this Search..." feature
+          name="q"
+          onChange={onChange}
+          placeholder={"Search for anything!"}
+          type="text"
+          value={q}
+        />
+        <input className="submit" title="Search" type="submit" value="" />
+      </form>
+    </div>
+  </>
 );
 
 type SortMode = "az" | "best" | "recent";
@@ -104,12 +115,15 @@ const Settings = ({
 
 const Sidebar = ({
   hiddenEngines,
+  onClose,
   resultGroups,
 }: {
   hiddenEngines: string[];
+  onClose: () => void;
   resultGroups: ResultGroup[];
 }) => (
   <div className="sidebar">
+    <button aria-label="Close engine list" className="sidebar-close" onClick={onClose}>✕</button>
     <ul>
       {Object.values(ENGINES)
         .sort((a, b) => (a.name > b.name ? 1 : -1))
@@ -363,6 +377,7 @@ const getUrlQ = () =>
 const App = () => {
   const [localData, setLocalData] = useState(STORAGE_MANAGER.get());
   const [q, setQ] = useState<string>("");
+  const [sidebarOpen, setSidebarOpen] = useState(false);
   const [resultGroups, dispatch] = useReducer(
     (state: ResultGroup[], action: ResultGroup | undefined) =>
       action ? [...state, action] : [],
@@ -385,8 +400,9 @@ const App = () => {
   }, [localData]);
 
   const sortMode: SortMode = localData.sortMode || "best";
+  const closeSidebar = () => setSidebarOpen(false);
   return (
-    <div className={`theme${localData.dark ? " dark" : ""}`}>
+    <div className={`theme${localData.dark ? " dark" : ""}${sidebarOpen ? " sidebar-open" : ""}`}>
       <div
         className="logo"
         onClick={() => {
@@ -399,6 +415,7 @@ const App = () => {
       </div>
       <Header
         onChange={e => setQ(e.target.value)}
+        onOpenSidebar={() => setSidebarOpen(true)}
         onSearch={q => handleSearch(dispatch, q, !!getUrlQ().trim())}
         q={q}
       />
@@ -414,8 +431,18 @@ const App = () => {
         }
         sortMode={sortMode}
       />
+      <div className="mobile-settings">
+        <a href="javascript:;" onClick={() => setLocalData({ ...localData, newTab: !localData.newTab })}>
+          {localData.newTab ? "New tab: on" : "New tab: off"}
+        </a>
+        <a href="javascript:;" onClick={() => setLocalData({ ...localData, dark: !localData.dark })} title="Toggle dark theme">
+          <img src="/theme.png" style={{ height: "18px", verticalAlign: "middle" }} />
+        </a>
+      </div>
+      <div className="sidebar-backdrop" onClick={closeSidebar} />
       <Sidebar
         hiddenEngines={localData.hiddenEngines || []}
+        onClose={closeSidebar}
         resultGroups={resultGroups}
       />
       <Results


### PR DESCRIPTION
## Summary
- Add `<meta name="viewport">` so mobile browsers render at device width
- Three-tier CSS breakpoints: desktop ≥1024px (unchanged), tablet 640–1023px (narrower sidebar/padding), mobile <640px (overlay sidebar, hamburger toggle, mobile settings row)
- Sidebar slides in as a fixed overlay on mobile with backdrop close; theme and new-tab toggles exposed via compact settings row below search bar

## Test plan
- [ ] Desktop (≥1024px): existing 3-column layout unchanged, sorter visible
- [ ] Tablet (640–1023px): sidebar visible at 200px, layout intact
- [ ] Mobile (<640px): search bar full-width, hamburger button visible, sidebar hidden; tap ☰ to open sidebar, tap ✕ or backdrop to close; theme/new-tab toggles accessible below search bar
- [ ] Dark mode works at all breakpoints
- [ ] Landscape mobile (short viewport): sorter/toggler/footer hidden, layout still usable

Closes PGM-144

🤖 Generated with [Claude Code](https://claude.com/claude-code)