### PR TITLE
ci: migrate docker build to kaniko (ARC kubernetes mode)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,36 +47,31 @@ jobs:
           echo "tag=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "full-ref=macro.int.pgmac.net:5000/pg-metasearch:${VERSION}" >> "$GITHUB_OUTPUT"
 
-      - name: Build Docker image
-        env:
-          TAG: ${{ steps.tag.outputs.tag }}
-        run: |
-          docker build \
-            -t "macro.int.pgmac.net:5000/pg-metasearch:${TAG}" \
-            .
-
-      - name: Tag as latest
+      - name: Build and push Docker image
         if: github.event_name == 'push'
-        env:
-          TAG: ${{ steps.tag.outputs.tag }}
-        run: |
-          docker tag \
-            "macro.int.pgmac.net:5000/pg-metasearch:${TAG}" \
-            "macro.int.pgmac.net:5000/pg-metasearch:latest"
+        uses: docker://gcr.io/kaniko-project/executor:v1.23.2-debug
+        with:
+          args: >-
+            --context=/github/workspace
+            --dockerfile=/github/workspace/Dockerfile
+            --destination=macro.int.pgmac.net:5000/pg-metasearch:${{ steps.tag.outputs.tag }}
+            --destination=macro.int.pgmac.net:5000/pg-metasearch:latest
+            --skip-tls-verify
+            --digest-file=/github/workspace/kaniko-digest.txt
 
-      - name: Push Docker image
+      - name: Build Docker image (PR, no push)
+        if: github.event_name == 'pull_request'
+        uses: docker://gcr.io/kaniko-project/executor:v1.23.2-debug
+        with:
+          args: >-
+            --context=/github/workspace
+            --dockerfile=/github/workspace/Dockerfile
+            --no-push
+
+      - name: Capture image digest
         id: push
         if: github.event_name == 'push'
-        env:
-          TAG: ${{ steps.tag.outputs.tag }}
-        run: |
-          docker push "macro.int.pgmac.net:5000/pg-metasearch:${TAG}"
-          docker push "macro.int.pgmac.net:5000/pg-metasearch:latest"
-          DIGEST=$(docker inspect \
-            --format='{{index .RepoDigests 0}}' \
-            "macro.int.pgmac.net:5000/pg-metasearch:${TAG}" \
-            | grep -oP 'sha256:[a-f0-9]+')
-          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+        run: echo "digest=$(cat /github/workspace/kaniko-digest.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Attest Docker image
         id: attest-image


### PR DESCRIPTION
## Summary

- Replaces `docker build`, `docker tag`, `docker push` steps with the kaniko executor container action
- Required because ARC self-hosted runners now use `containerMode: kubernetes` (no Docker daemon available) — see pgmac-net/pgk8s#415
- Digest captured via kaniko `--digest-file` for downstream attestation steps (preserves `steps.push.outputs.digest`)

## How it works

Kaniko builds and pushes both the versioned tag and `latest` in a single step. On PRs, `--no-push` is used (build validation only).

## Test plan

- [ ] CI passes on this PR (build-only, no push)
- [ ] Merge and verify image pushed to `macro.int.pgmac.net:5000/pg-metasearch`
- [ ] Verify attestation step still receives digest correctly

Refs: PGM-155

🤖 Generated with [Claude Code](https://claude.com/claude-code)