### PR TITLE
fix(ci): grant pull-requests:write to sbom reusable workflow caller

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -16,3 +16,4 @@ jobs:
       security-events: write
       id-token: write
       actions: read
+      pull-requests: write


### PR DESCRIPTION
## Summary

- `pg-actions` commit `f283f3f` (Apr 5) added `pull-requests: write` to the `GHAS-dependency-scan` job in the reusable `sbom.yml` workflow
- When a caller specifies explicit `permissions:`, GitHub restricts the called workflow to only those permissions and fails the run at startup if the called workflow requests more
- This caused every `sbom.yml` run since Apr 15 to fail with `startup_failure` (no jobs queued)

## Test plan

- [ ] Merge and verify the "Build a bill of materials ... and scan it" workflow run completes without `startup_failure`

🤖 Generated with [Claude Code](https://claude.com/claude-code)