### PR TITLE
chore: bump pg-actions sbom.yml to 218190a (main)

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   sbom:
-    uses: pgmac-net/pg-actions/.github/workflows/sbom.yml@5038ef37473d41e1a00172607768fd9af735407e # main
+    uses: pgmac-net/pg-actions/.github/workflows/sbom.yml@218190ac9d3b18aa9f3225e910bf8c6801408abc # main
     secrets: inherit
     permissions:
       attestations: write


### PR DESCRIPTION
Bumps `pgmac-net/pg-actions/.github/workflows/sbom.yml` pin to `218190a` (main).

Picks up:
- fix: replace DependencyTrack/gh-upload-sbom node20 action with curl (#80)
- fix: avoid ARG_MAX limit when uploading large SBoMs to DTrack (#81)
- fix: use mise install script instead of GitHub releases download (#79)
- fix: switch gh and syft from aqua to github backend (#78)

🤖 Generated with [Claude Code](https://claude.com/claude-code)