### PR TITLE
feat: add actions, security, discussions, wiki search to GitHub engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The full list of supported data sources:
 - [Confluence](https://www.atlassian.com/software/confluence) pages
 - [Dropbox](https://www.dropbox.com/) files and folders
 - [Figma](https://www.figma.com/) files, projects, and teams
-- [GitHub](https://github.com/) PRs, issues, and repo metadata
+- [GitHub](https://github.com/) PRs, issues, discussions, wiki pages, workflows, security advisories, and repo metadata
 - [GitLab](https://gitlab.com/) merge-requests
 - [Google Drive](https://www.google.com/drive/) docs, spreadsheets, etc.
 - [Google Groups](https://groups.google.com/) groups

--- a/docs/github-engine-expansion.md
+++ b/docs/github-engine-expansion.md
@@ -1,0 +1,36 @@
+# GitHub Engine Expansion
+
+**Issue:** pgmac-net/metasearch#23
+**PR:** pgmac-net/metasearch#26
+**Date:** 2026-07-26
+
+## Work
+
+Extended the GitHub search engine to cover four new data sources beyond the existing repo metadata and issue/PR search.
+
+### New Sources
+
+| Source | API | Approach |
+|---|---|---|
+| **Actions** | `GET /search/code` with `path:.github/workflows` | Searches workflow file names and contents across the org |
+| **Security advisories** | `GET /orgs/{org}/security-advisories` | Fetches all advisories, filters client-side |
+| **Dependabot alerts** | `GET /orgs/{org}/dependabot/alerts` | Fetches open alerts, filters by advisory summary/package name |
+| **Code scanning alerts** | `GET /orgs/{org}/code-scanning/alerts` | Fetches alerts, filters by rule name/description |
+| **Secret scanning alerts** | `GET /orgs/{org}/secret-scanning/alerts` | Fetches open alerts, filters by secret type name |
+| **Discussions** | GraphQL `search(type: DISCUSSION)` | Searches org discussions via GraphQL search API |
+| **Wiki** | `GET /repos/{org}/{repo}/contents?ref=wiki/master` | Iterates repos in parallel, filters wiki page names |
+
+### Architecture
+
+The existing monolithic `search` function was refactored into named helper functions — one per source — called in parallel via `Promise.all` within the org loop. Each helper is wrapped in try/catch returning `[]` on failure, so one unavailable endpoint doesn't break the full search.
+
+### Decisions
+
+- **Per-repo vs org-level APIs:** Where org-level endpoints exist (security alerts, advisories), those are preferred. Wiki requires per-repo iteration since no cross-repo wiki search API exists.
+- **Client-side filtering:** Alert endpoints don't support text search parameters, so all items are fetched (up to 50 per source) and filtered with `fuzzyIncludes`.
+- **No new config options:** All new sources reuse the existing `organizations`, `token`, and `origin` config. No additional GitHub permissions are required beyond what the existing token already grants — endpoints silently return empty if the token lacks access.
+- **Wiki search scope:** Only top-level wiki `.md` files are searched (the Contents API on the wiki branch returns flat listings). Nested wiki subdirectories are not traversed.
+
+### Deviation from Plan
+
+- Implemented on DeepSeek instead of the planned Sonnet (user preference — no model switch available).

--- a/src/engines/github.ts
+++ b/src/engines/github.ts
@@ -95,75 +95,301 @@ const engine: Engine = {
     for (const org of orgs) {
       const orgRepos = repos.get(org) || new Set();
 
-      const [repoResults, issueResults] = await Promise.all([
-        // Search repo names and descriptions
-        (async () =>
-          Array.from(orgRepos)
-            .filter(
-              (r) =>
-                !r.isArchived &&
-                !r.isFork &&
-                [r.description, r.name].some((s) => fuzzyIncludes(s, q))
-            )
-            .sort((a, b) => (a.name > b.name ? 1 : -1))
-            .map((r) => ({
-              snippet:
-                r.description?.replace(/ *:[a-z-]+: */g, "") || undefined,
-              title: `Repo ${org}/${r.name}`,
-              url: `https://github.com/${org}/${r.name}`,
-            })))(),
-        // Search issues and pull requests
-        (async () => {
-          try {
-            // TODO: Paginate
-            // https://developer.github.com/v3/search/#search-issues-and-pull-requests
-            const data: {
-              items: {
-                body: null | string;
-                html_url: string;
-                number: number;
-                pull_request?: object;
-                title: string;
-                /** e.g. "2020-06-29T21:46:58Z" */
-                updated_at: string;
-                user: { login: string };
-              }[];
-            } = (
-              await client.get("/search/issues", {
-                params: {
-                  per_page: 100,
-                  q: /\b(is|author|org):\w/.test(q)
-                    ? /\borg:\w/.test(q)
-                      ? q
-                      : `org:${org} ${q}`
-                    : `org:${org} "${escapeQuotes(q)}"`,
-                },
-              })
-            ).data;
-            const parse = await getMarkedParse();
-            return data.items.map((item) => ({
-              modified: getUnixTime(item.updated_at),
-              snippet: item.body
-                ? `<blockquote>${parse(item.body)}</blockquote>`
-                : undefined,
-              title: `${item.pull_request ? "PR" : "Issue"} in ${
-                item.html_url.match(/github\.com\/([^\/]+\/[^\/]+)/)?.[1]
-              }: ${item.title}`,
-              url: item.html_url,
-            }));
-          } catch {
-            // Ignore errors for now
-            return [];
-          }
-        })(),
+      const [
+        repoResults,
+        issueResults,
+        workflowResults,
+        advisoryResults,
+        discussionResults,
+        wikiResults,
+      ] = await Promise.all([
+        searchRepos(orgRepos, org, q),
+        searchIssues(client, org, q),
+        searchWorkflows(client, org, q),
+        searchSecurity(client, org, q),
+        searchDiscussions(client, org, q),
+        searchWiki(client, Array.from(orgRepos), org, q),
       ]);
 
-      results.push(...repoResults, ...issueResults);
+      results.push(
+        ...repoResults,
+        ...issueResults,
+        ...workflowResults,
+        ...advisoryResults,
+        ...discussionResults,
+        ...wikiResults,
+      );
     }
 
     return results;
   },
 };
+
+async function searchRepos(
+  orgRepos: Set<Repo>,
+  org: string,
+  q: string,
+): Promise<Result[]> {
+  return Array.from(orgRepos)
+    .filter(
+      (r) =>
+        !r.isArchived &&
+        !r.isFork &&
+        [r.description, r.name].some((s) => fuzzyIncludes(s, q)),
+    )
+    .sort((a, b) => (a.name > b.name ? 1 : -1))
+    .map((r) => ({
+      snippet: r.description?.replace(/ *:[a-z-]+: */g, "") || undefined,
+      title: `Repo ${org}/${r.name}`,
+      url: `https://github.com/${org}/${r.name}`,
+    }));
+}
+
+async function searchIssues(
+  client: AxiosInstance,
+  org: string,
+  q: string,
+): Promise<Result[]> {
+  try {
+    const data: {
+      items: {
+        body: null | string;
+        html_url: string;
+        number: number;
+        pull_request?: object;
+        title: string;
+        updated_at: string;
+        user: { login: string };
+      }[];
+    } = (
+      await client.get("/search/issues", {
+        params: {
+          per_page: 100,
+          q: /\b(is|author|org):\w/.test(q)
+            ? /\borg:\w/.test(q)
+              ? q
+              : `org:${org} ${q}`
+            : `org:${org} "${escapeQuotes(q)}"`,
+        },
+      })
+    ).data;
+    const parse = await getMarkedParse();
+    return data.items.map((item) => ({
+      modified: getUnixTime(item.updated_at),
+      snippet: item.body
+        ? `<blockquote>${parse(item.body)}</blockquote>`
+        : undefined,
+      title: `${item.pull_request ? "PR" : "Issue"} in ${
+        item.html_url.match(/github\.com\/([^\/]+\/[^\/]+)/)?.[1]
+      }: ${item.title}`,
+      url: item.html_url,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+async function searchWorkflows(
+  client: AxiosInstance,
+  org: string,
+  q: string,
+): Promise<Result[]> {
+  try {
+    const { data } = await client.get("/search/code", {
+      params: {
+        q: `org:${org} path:.github/workflows ${escapeQuotes(q)}`,
+        per_page: 20,
+      },
+    });
+    return (data.items || []).map((item: any) => ({
+      title: `Workflow: ${item.path.replace(".github/workflows/", "")} in ${item.repository.full_name}`,
+      url: item.html_url,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+async function searchSecurity(
+  client: AxiosInstance,
+  org: string,
+  q: string,
+): Promise<Result[]> {
+  const results: Result[] = [];
+
+  await Promise.all([
+    (async () => {
+      try {
+        const { data } = await client.get(`/orgs/${org}/security-advisories`, {
+          params: { per_page: 50 },
+        });
+        for (const a of data || []) {
+          if (
+            fuzzyIncludes(a.title, q) ||
+            fuzzyIncludes(a.description, q) ||
+            fuzzyIncludes(a.summary, q)
+          ) {
+            results.push({
+              title: `Security advisory: ${a.title || a.summary}`,
+              url: a.html_url,
+              snippet: a.description || a.summary,
+              modified: a.updated_at ? getUnixTime(a.updated_at) : undefined,
+            });
+          }
+        }
+      } catch {
+        // Security advisories endpoint may not be available
+      }
+    })(),
+    (async () => {
+      try {
+        const { data } = await client.get(`/orgs/${org}/dependabot/alerts`, {
+          params: { per_page: 50, state: "open" },
+        });
+        for (const a of data || []) {
+          const text =
+            a.security_advisory?.summary ||
+            a.security_advisory?.description ||
+            a.package?.name ||
+            "";
+          if (fuzzyIncludes(text, q)) {
+            results.push({
+              title: `Dependabot: ${a.security_advisory?.summary || a.package?.name || "alert"}`,
+              url: a.html_url,
+              snippet: a.security_advisory?.description,
+              modified: a.created_at ? getUnixTime(a.created_at) : undefined,
+            });
+          }
+        }
+      } catch {
+        // Dependabot alerts endpoint may not be available
+      }
+    })(),
+    (async () => {
+      try {
+        const { data } = await client.get(`/orgs/${org}/code-scanning/alerts`, {
+          params: { per_page: 50 },
+        });
+        for (const a of data || []) {
+          const text = a.rule?.name || a.rule?.description || "";
+          if (fuzzyIncludes(text, q)) {
+            results.push({
+              title: `Code scanning: ${a.rule?.name || "alert"}`,
+              url: a.html_url,
+              snippet: a.rule?.description,
+              modified: a.created_at ? getUnixTime(a.created_at) : undefined,
+            });
+          }
+        }
+      } catch {
+        // Code scanning alerts endpoint may not be available
+      }
+    })(),
+    (async () => {
+      try {
+        const { data } = await client.get(`/orgs/${org}/secret-scanning/alerts`, {
+          params: { per_page: 50, state: "open" },
+        });
+        for (const a of data || []) {
+          if (fuzzyIncludes(a.secret_type_display_name, q)) {
+            results.push({
+              title: `Secret scanning: ${a.secret_type_display_name}`,
+              url: a.html_url,
+              modified: a.created_at ? getUnixTime(a.created_at) : undefined,
+            });
+          }
+        }
+      } catch {
+        // Secret scanning alerts endpoint may not be available
+      }
+    })(),
+  ]);
+
+  return results;
+}
+
+async function searchDiscussions(
+  client: AxiosInstance,
+  org: string,
+  q: string,
+): Promise<Result[]> {
+  try {
+    const response = await client.post(
+      "/graphql",
+      JSON.stringify({
+        query: `{
+          search(query: "org:${org} is:discussion ${escapeQuotes(q)}", type: DISCUSSION, first: 50) {
+            edges {
+              node {
+                ... on Discussion {
+                  title
+                  url
+                  body
+                  updatedAt
+                }
+              }
+            }
+          }
+        }`,
+      }),
+    );
+
+    const edges = response.data?.data?.search?.edges || [];
+    const parse = await getMarkedParse();
+    return edges.map(({ node }: any) => ({
+      title: `Discussion: ${node.title}`,
+      url: node.url,
+      snippet: node.body
+        ? `<blockquote>${parse(node.body)}</blockquote>`
+        : undefined,
+      modified: node.updatedAt ? getUnixTime(node.updatedAt) : undefined,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+async function searchWiki(
+  client: AxiosInstance,
+  repos: Repo[],
+  org: string,
+  q: string,
+): Promise<Result[]> {
+  const activeRepos = repos.filter((r) => !r.isArchived && !r.isFork);
+
+  const pageResults = await Promise.all(
+    activeRepos.map(async (repo) => {
+      try {
+        const { data } = await client.get(
+          `/repos/${org}/${repo.name}/contents`,
+          { params: { ref: "wiki/master" } },
+        );
+        if (!Array.isArray(data)) {
+          return [] as Result[];
+        }
+        return data
+          .filter(
+            (f: any) =>
+              f.type === "file" &&
+              f.name.endsWith(".md") &&
+              fuzzyIncludes(f.name.replace(/\.md$/i, ""), q),
+          )
+          .map(
+            (f: any): Result => ({
+              title: `Wiki: ${f.name.replace(/\.md$/i, "")} (${org}/${repo.name})`,
+              url: `https://github.com/${org}/${repo.name}/wiki/${encodeURIComponent(
+                f.name.replace(/\.md$/i, ""),
+              )}`,
+            }),
+          );
+      } catch {
+        return [] as Result[];
+      }
+    }),
+  );
+
+  return pageResults.flat();
+}
 
 export default engine;
 


### PR DESCRIPTION
Extends the GitHub engine to search four new data sources beyond the existing repo and issue/PR search:

**Actions** — searches workflow files in `.github/workflows` via the code search API.

**Security** — searches security advisories, dependabot alerts, code scanning alerts, and secret scanning alerts via org-level API endpoints.

**Discussions** — searches GitHub Discussions via GraphQL.

**Wiki** — searches wiki page names by listing repo wiki contents via the Contents API.

Refactors the search function into separate helper functions for each source, keeping the same error-handling pattern (per-source try/catch returns empty array on failure).

Closes pgmac-net/metasearch#23

Complexity: STANDARD — implement on Sonnet