### PR TITLE
Add gotchas-only CLAUDE.md, move architecture to docs/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,18 @@
+# CLAUDE.md
+
+Parallel search aggregator — one query fans out to all configured engines. Full architecture: `docs/ARCHITECTURE.md`.
+
+## Commands
+
+```bash
+make build       # Install npm deps, compile TypeScript, minify UI JS, compile Sass
+make             # Build then serve (local dev, port 3000)
+make oauth       # Generate Google OAuth refresh token
+make oauth_microsoft  # Generate Microsoft Graph OAuth refresh token
+```
+
+## Gotchas
+
+- TypeScript compile needs `NODE_OPTIONS=--max_old_space_size=4096` (already set in Makefile) — 4GB heap, or it OOMs
+- Docker builds on this host need `--network=host` — containers here can't reach the internet otherwise
+- Config path differs by environment: `config.yaml` locally, `/data/config.yaml` in Docker (see `docs/ARCHITECTURE.md`)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,31 @@
+# Architecture
+
+Metasearch is a parallel search aggregator — a single query fans out to all configured engines simultaneously and aggregates results.
+
+## Request flow
+
+1. `src/index.ts` — Express server (port 3000) loads `config.yaml`, registers all enabled engines, handles `GET /` (search UI) and `GET /search` (JSON results)
+2. `src/engines/index.ts` — engine registry; exports all engine implementations
+3. `src/engines/<name>.ts` — each engine queries one external service and returns `{ title, url, snippet?, modified? }[]`
+4. `src/util.ts` — shared helpers: `sanitizeHtml`, `fuzzyIncludes`, `rateLimit`, `stripStopWords`, `escapeQuotes`
+
+## Config loading (`src/index.ts`)
+
+- Local: reads `config.yaml` from the project root
+- Docker: reads `/data/config.yaml` (detected via `/.dockerenv` or `/run/.containerenv`)
+- `${ENV_VAR}` syntax in the YAML is expanded from environment variables at startup
+- Copy `config-example.yaml` → `config.yaml`; each engine section key must match the engine's registered name — only engines with a config section are enabled
+
+## Adding an engine
+
+1. Create `src/engines/<name>.ts` — export an async function matching the engine interface (any existing engine is a working template)
+2. Register it in `src/engines/index.ts`
+3. Add a sample config block to `config-example.yaml`
+
+The function receives the per-engine config object and the search query string, and must handle its own errors (log and return `[]`) so one failing engine doesn't break the whole response.
+
+## CI/CD
+
+`.github/workflows/docker.yml` — builds on PR, builds+pushes to `macro.int.pgmac.net:5000` on merge to master, generates a CycloneDX SBoM from the image, attests both image and SBoM, uploads to Dependency Track (`dtrack.int.pgmac.net`) using org-level secret `DT_APIKEY`.
+
+`.github/workflows/sbom.yml` — separate source-level SBoM workflow (reusable workflow from `pgmac-net/pg-actions`).


### PR DESCRIPTION
## Summary

`CLAUDE.md` existed on disk but had never been committed to this repo. Bringing it under version control in the trimmed shape directly:

- CLAUDE.md: gotchas + non-discoverable commands only
- New `docs/ARCHITECTURE.md`: request flow, config-loading detail, engine-extension recipe, CI/CD

Part of the wider Claude Code docs cleanup: pgmac-net/homelabia#151

Note: this branch does not touch the other untracked files present in the working tree (`renovate.pgp.key`/`.pub`, `package-*-pre.json`, `start_metasearch.sh`) — those look like your in-progress local work and are left exactly as-is.

## Test plan

- [ ] `docs/ARCHITECTURE.md` matches current `src/` layout
- [ ] Nothing load-bearing dropped from the original local CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JgbGfmY1Z3BopzDdsmkY52